### PR TITLE
SwipeRefreshLayout support

### DIFF
--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -54,6 +54,9 @@
       android:label="@string/title_activity_gsd_quick_return"
       android:name=".activity.GsdQuickReturnActivity" />
     <activity
+      android:label="@string/title_activity_gsd_swipe_refresh_layout"
+      android:name=".activity.GsdSwipeRefreshLayoutActivity" />
+    <activity
       android:label="@string/title_activity_smooth_scroll"
       android:name=".activity.SmoothScrollActivity" />
     <activity
@@ -71,6 +74,9 @@
     <activity
       android:label="@string/title_activity_smooth_scroll_exit_until_collapsed"
       android:name=".activity.SmoothQuickReturnActivity" />
+    <activity
+      android:label="@string/title_activity_smooth_swipe_refresh_layout"
+      android:name=".activity.SmoothSwipeRefreshLayoutActivity" />
 
     <!-- other examples -->
     <activity

--- a/sample/src/main/java/me/henrytao/smoothappbarlayoutdemo/activity/GsdScrollActivity.java
+++ b/sample/src/main/java/me/henrytao/smoothappbarlayoutdemo/activity/GsdScrollActivity.java
@@ -26,7 +26,6 @@ import butterknife.Bind;
 import butterknife.ButterKnife;
 import me.henrytao.smoothappbarlayoutdemo.R;
 import me.henrytao.smoothappbarlayoutdemo.apdater.DynamicAdapter;
-import me.henrytao.smoothappbarlayoutdemo.apdater.SimpleAdapter;
 import me.henrytao.smoothappbarlayoutdemo.util.Utils;
 
 public class GsdScrollActivity extends BaseActivity {

--- a/sample/src/main/java/me/henrytao/smoothappbarlayoutdemo/activity/GsdSwipeRefreshLayoutActivity.java
+++ b/sample/src/main/java/me/henrytao/smoothappbarlayoutdemo/activity/GsdSwipeRefreshLayoutActivity.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2016 "Henry Tao <hi@henrytao.me>"
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.henrytao.smoothappbarlayoutdemo.activity;
+
+import android.os.Bundle;
+import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.RecyclerView;
+import android.support.v7.widget.Toolbar;
+import android.view.View;
+
+import butterknife.Bind;
+import butterknife.ButterKnife;
+import me.henrytao.smoothappbarlayoutdemo.R;
+import me.henrytao.smoothappbarlayoutdemo.apdater.DynamicAdapter;
+import me.henrytao.smoothappbarlayoutdemo.util.Utils;
+
+public class GsdSwipeRefreshLayoutActivity extends BaseActivity {
+
+  @Bind(android.R.id.list)
+  RecyclerView vRecyclerView;
+
+  @Bind(R.id.toolbar)
+  Toolbar vToolbar;
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_gsd_swipe_refresh_layout);
+    ButterKnife.bind(this);
+
+    setSupportActionBar(vToolbar);
+    vToolbar.setNavigationOnClickListener(new View.OnClickListener() {
+      @Override
+      public void onClick(View v) {
+        onBackPressed();
+      }
+    });
+
+    vRecyclerView.setLayoutManager(new LinearLayoutManager(this));
+    vRecyclerView.setAdapter(new DynamicAdapter(Utils.getSampleData()));
+  }
+}

--- a/sample/src/main/java/me/henrytao/smoothappbarlayoutdemo/activity/MainActivity.java
+++ b/sample/src/main/java/me/henrytao/smoothappbarlayoutdemo/activity/MainActivity.java
@@ -111,6 +111,8 @@ public class MainActivity extends BaseActivity implements SimpleAdapter.OnItemCl
     features.add(new Feature(SmoothViewPagerQuickReturnActivity.class, "ViewPager | QuickReturn"));
     features.add(new Feature(null, "N/A"));
     features.add(new Feature(SmoothViewPagerParallaxExitUntilCollapsedActivity.class, "ViewPager Parallax | exitUntilCollapsed"));
+    features.add(new Feature(GsdSwipeRefreshLayoutActivity.class, "SwipeRefreshLayout"));
+    features.add(new Feature(SmoothSwipeRefreshLayoutActivity.class, "SwipeRefreshLayout"));
     return features;
   }
 

--- a/sample/src/main/java/me/henrytao/smoothappbarlayoutdemo/activity/SmoothSwipeRefreshLayoutActivity.java
+++ b/sample/src/main/java/me/henrytao/smoothappbarlayoutdemo/activity/SmoothSwipeRefreshLayoutActivity.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2016 "Henry Tao <hi@henrytao.me>"
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.henrytao.smoothappbarlayoutdemo.activity;
+
+import android.os.Bundle;
+import android.support.v4.widget.SwipeRefreshLayout;
+import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.RecyclerView;
+import android.support.v7.widget.Toolbar;
+import android.support.v7.widget.helper.ItemTouchHelper;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import butterknife.Bind;
+import butterknife.ButterKnife;
+import me.henrytao.mdcore.utils.ResourceUtils;
+import me.henrytao.recyclerview.SimpleRecyclerViewAdapter;
+import me.henrytao.recyclerview.holder.HeaderHolder;
+import me.henrytao.smoothappbarlayout.SmoothAppBarLayout;
+import me.henrytao.smoothappbarlayout.base.ScrollTargetCallback;
+import me.henrytao.smoothappbarlayoutdemo.R;
+import me.henrytao.smoothappbarlayoutdemo.apdater.DynamicAdapter;
+import me.henrytao.smoothappbarlayoutdemo.util.Utils;
+
+public class SmoothSwipeRefreshLayoutActivity extends BaseActivity {
+
+  @Bind(android.R.id.list)
+  RecyclerView vRecyclerView;
+
+  @Bind(R.id.toolbar)
+  Toolbar vToolbar;
+
+  @Bind(R.id.smooth_app_bar_layout)
+  SmoothAppBarLayout vSmoothAppBarLayout;
+
+  @Bind(R.id.swipe_refresh_layout)
+  SwipeRefreshLayout vSwipeRefreshLayout;
+
+  private DynamicAdapter<String> mAdapter;
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_smooth_swipe_refresh_layout);
+    ButterKnife.bind(this);
+
+    setSupportActionBar(vToolbar);
+    vToolbar.setNavigationOnClickListener(new View.OnClickListener() {
+      @Override
+      public void onClick(View v) {
+        onBackPressed();
+      }
+    });
+
+    mAdapter = new DynamicAdapter<>(Utils.getSampleData());
+    RecyclerView.Adapter adapter = new SimpleRecyclerViewAdapter(mAdapter) {
+      @Override
+      public RecyclerView.ViewHolder onCreateFooterViewHolder(LayoutInflater layoutInflater, ViewGroup viewGroup) {
+        return null;
+      }
+
+      @Override
+      public RecyclerView.ViewHolder onCreateHeaderViewHolder(LayoutInflater layoutInflater, ViewGroup viewGroup) {
+        return new HeaderHolder(layoutInflater, viewGroup, R.layout.item_header_spacing);
+      }
+    };
+
+    vRecyclerView.setLayoutManager(new LinearLayoutManager(this));
+    vRecyclerView.setAdapter(adapter);
+
+    ItemTouchHelper itemTouchHelper = new ItemTouchHelper(new ItemTouchHelper.SimpleCallback(0, ItemTouchHelper.RIGHT) {
+      @Override
+      public boolean onMove(RecyclerView recyclerView, RecyclerView.ViewHolder viewHolder, RecyclerView.ViewHolder target) {
+        return false;
+      }
+
+      @Override
+      public void onSwiped(RecyclerView.ViewHolder viewHolder, int direction) {
+        mAdapter.remove((int) viewHolder.itemView.getTag(R.id.tag_position));
+      }
+    });
+    itemTouchHelper.attachToRecyclerView(vRecyclerView);
+
+    vSmoothAppBarLayout.setScrollTargetCallback(new ScrollTargetCallback() {
+      @Override
+      public View callback(View target) {
+        return vRecyclerView;
+      }
+    });
+
+    // set proper offset for swipe refresh layout
+    // set offset for swipe refresh layouts
+    int actionBarSize = ResourceUtils.getActionBarSize(this);
+    int progressViewStart = getResources().getDimensionPixelSize(R.dimen.app_bar_height) -
+            actionBarSize;
+    int progressViewEnd = progressViewStart + (int) (actionBarSize * 1.5f);
+    vSwipeRefreshLayout.setProgressViewOffset(true, progressViewStart, progressViewEnd);
+  }
+}

--- a/sample/src/main/java/me/henrytao/smoothappbarlayoutdemo/activity/SmoothSwipeRefreshLayoutActivity.java
+++ b/sample/src/main/java/me/henrytao/smoothappbarlayoutdemo/activity/SmoothSwipeRefreshLayoutActivity.java
@@ -96,15 +96,7 @@ public class SmoothSwipeRefreshLayoutActivity extends BaseActivity {
     });
     itemTouchHelper.attachToRecyclerView(vRecyclerView);
 
-    vSmoothAppBarLayout.setScrollTargetCallback(new ScrollTargetCallback() {
-      @Override
-      public View callback(View target) {
-        return vRecyclerView;
-      }
-    });
-
-    // set proper offset for swipe refresh layout
-    // set offset for swipe refresh layouts
+    // set progress view offset
     int actionBarSize = ResourceUtils.getActionBarSize(this);
     int progressViewStart = getResources().getDimensionPixelSize(R.dimen.app_bar_height) -
             actionBarSize;

--- a/sample/src/main/java/me/henrytao/smoothappbarlayoutdemo/activity/SmoothSwipeRefreshLayoutActivity.java
+++ b/sample/src/main/java/me/henrytao/smoothappbarlayoutdemo/activity/SmoothSwipeRefreshLayoutActivity.java
@@ -17,6 +17,7 @@
 package me.henrytao.smoothappbarlayoutdemo.activity;
 
 import android.os.Bundle;
+import android.os.Handler;
 import android.support.v4.widget.SwipeRefreshLayout;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
@@ -32,7 +33,6 @@ import me.henrytao.mdcore.utils.ResourceUtils;
 import me.henrytao.recyclerview.SimpleRecyclerViewAdapter;
 import me.henrytao.recyclerview.holder.HeaderHolder;
 import me.henrytao.smoothappbarlayout.SmoothAppBarLayout;
-import me.henrytao.smoothappbarlayout.base.ScrollTargetCallback;
 import me.henrytao.smoothappbarlayoutdemo.R;
 import me.henrytao.smoothappbarlayoutdemo.apdater.DynamicAdapter;
 import me.henrytao.smoothappbarlayoutdemo.util.Utils;
@@ -42,16 +42,20 @@ public class SmoothSwipeRefreshLayoutActivity extends BaseActivity {
   @Bind(android.R.id.list)
   RecyclerView vRecyclerView;
 
-  @Bind(R.id.toolbar)
-  Toolbar vToolbar;
-
   @Bind(R.id.smooth_app_bar_layout)
   SmoothAppBarLayout vSmoothAppBarLayout;
 
   @Bind(R.id.swipe_refresh_layout)
   SwipeRefreshLayout vSwipeRefreshLayout;
 
+  @Bind(R.id.toolbar)
+  Toolbar vToolbar;
+
   private DynamicAdapter<String> mAdapter;
+
+  private Runnable mCallback;
+
+  private Handler mHandler;
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
@@ -99,8 +103,32 @@ public class SmoothSwipeRefreshLayoutActivity extends BaseActivity {
     // set progress view offset
     int actionBarSize = ResourceUtils.getActionBarSize(this);
     int progressViewStart = getResources().getDimensionPixelSize(R.dimen.app_bar_height) -
-            actionBarSize;
+        actionBarSize;
     int progressViewEnd = progressViewStart + (int) (actionBarSize * 1.5f);
     vSwipeRefreshLayout.setProgressViewOffset(true, progressViewStart, progressViewEnd);
+
+    mHandler = new Handler();
+    mCallback = new Runnable() {
+      @Override
+      public void run() {
+        if (!isFinishing()) {
+          vSwipeRefreshLayout.setRefreshing(false);
+        }
+      }
+    };
+    vSwipeRefreshLayout.setOnRefreshListener(new SwipeRefreshLayout.OnRefreshListener() {
+      @Override
+      public void onRefresh() {
+        mHandler.postDelayed(mCallback, 2000);
+      }
+    });
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mHandler.removeCallbacks(mCallback);
+    mCallback = null;
+    mHandler = null;
   }
 }

--- a/sample/src/main/java/me/henrytao/smoothappbarlayoutdemo/apdater/DynamicAdapter.java
+++ b/sample/src/main/java/me/henrytao/smoothappbarlayoutdemo/apdater/DynamicAdapter.java
@@ -24,7 +24,6 @@ import android.view.ViewGroup;
 import android.widget.TextView;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 
 import butterknife.Bind;

--- a/sample/src/main/res/layout/activity_gsd_swipe_refresh_layout.xml
+++ b/sample/src/main/res/layout/activity_gsd_swipe_refresh_layout.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright 2016 "Henry Tao <hi@henrytao.me>"
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<android.support.design.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  android:layout_width="match_parent"
+  android:layout_height="match_parent">
+
+  <android.support.v4.widget.SwipeRefreshLayout
+      android:id="@+id/swipe_refresh_layout"
+      android:layout_width="match_parent"
+      android:layout_height="match_parent"
+      app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+    <android.support.v7.widget.RecyclerView
+      android:id="@android:id/list"
+      android:layout_width="match_parent"
+      android:layout_height="match_parent"/>
+
+  </android.support.v4.widget.SwipeRefreshLayout>
+
+  <android.support.design.widget.AppBarLayout
+    android:layout_width="match_parent"
+    android:layout_height="@dimen/app_bar_height">
+
+    <android.support.design.widget.CollapsingToolbarLayout
+      android:id="@+id/collapsing_toolbar_layout"
+      android:layout_width="match_parent"
+      android:layout_height="match_parent"
+      app:layout_scrollFlags="scroll">
+
+      <android.support.v7.widget.Toolbar
+        android:id="@+id/toolbar"
+        app:layout_collapseMode="pin"
+        app:navigationIcon="@drawable/ic_menu_arrow_back"
+        style="@style/AppStyle.MdToolbar" />
+    </android.support.design.widget.CollapsingToolbarLayout>
+  </android.support.design.widget.AppBarLayout>
+</android.support.design.widget.CoordinatorLayout>

--- a/sample/src/main/res/layout/activity_gsd_swipe_refresh_layout.xml
+++ b/sample/src/main/res/layout/activity_gsd_swipe_refresh_layout.xml
@@ -20,15 +20,15 @@
   android:layout_height="match_parent">
 
   <android.support.v4.widget.SwipeRefreshLayout
-      android:id="@+id/swipe_refresh_layout"
-      android:layout_width="match_parent"
-      android:layout_height="match_parent"
-      app:layout_behavior="@string/appbar_scrolling_view_behavior">
+    android:id="@+id/swipe_refresh_layout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
     <android.support.v7.widget.RecyclerView
       android:id="@android:id/list"
       android:layout_width="match_parent"
-      android:layout_height="match_parent"/>
+      android:layout_height="match_parent" />
 
   </android.support.v4.widget.SwipeRefreshLayout>
 

--- a/sample/src/main/res/layout/activity_smooth_swipe_refresh_layout.xml
+++ b/sample/src/main/res/layout/activity_smooth_swipe_refresh_layout.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright 2016 "Henry Tao <hi@henrytao.me>"
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<android.support.design.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  android:layout_width="match_parent"
+  android:layout_height="match_parent">
+
+  <android.support.v4.widget.SwipeRefreshLayout
+    android:id="@+id/swipe_refresh_layout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <android.support.v7.widget.RecyclerView
+      android:id="@android:id/list"
+      android:layout_width="match_parent"
+      android:layout_height="match_parent" />
+
+  </android.support.v4.widget.SwipeRefreshLayout>
+
+  <me.henrytao.smoothappbarlayout.SmoothAppBarLayout
+    android:id="@+id/smooth_app_bar_layout"
+    android:layout_width="match_parent"
+    android:layout_height="@dimen/app_bar_height">
+
+    <android.support.design.widget.CollapsingToolbarLayout
+      android:id="@+id/collapsing_toolbar_layout"
+      android:layout_width="match_parent"
+      android:layout_height="match_parent"
+      app:layout_scrollFlags="scroll">
+
+      <android.support.v7.widget.Toolbar
+        android:id="@+id/toolbar"
+        app:layout_collapseMode="pin"
+        app:navigationIcon="@drawable/ic_menu_arrow_back"
+        style="@style/AppStyle.MdToolbar" />
+    </android.support.design.widget.CollapsingToolbarLayout>
+  </me.henrytao.smoothappbarlayout.SmoothAppBarLayout>
+</android.support.design.widget.CoordinatorLayout>

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -103,6 +103,7 @@
   <string name="title_activity_gsd_scroll_snap">Gsd scroll | snap</string>
   <string name="title_activity_gsd_quick_return">Gsd quickReturn</string>
   <string name="title_activity_gsd_view_pager">Gsd ViewPager</string>
+  <string name="title_activity_gsd_swipe_refresh_layout">Gsd SwipeRefreshLayout</string>
   <string name="title_activity_smooth_scroll">Smooth scroll</string>
   <string name="title_activity_smooth_scroll_enter_always">Smooth scroll | enterAlways</string>
   <string name="title_activity_smooth_scroll_enter_always_collapsed">Smooth scroll | enterAlwaysCollapsed</string>
@@ -115,6 +116,7 @@
   <string name="title_activity_smooth_view_pager_exit_until_collapsed">Smooth ViewPager | exitUntilCollapsed</string>
   <string name="title_activity_smooth_view_pager_quick_return">Smooth ViewPager QuickReturn</string>
   <string name="title_activity_smooth_view_pager_parallax_exit_until_collapsed">Smooth ViewPager Parallax | exitUntilCollapsed</string>
+  <string name="title_activity_smooth_swipe_refresh_layout">Smooth SwipeRefreshLayout</string>
   <string name="title_activity_feature">FeatureActivity</string>
   <string name="title_activity_inbox">Inbox</string>
   <string name="close">Close</string>

--- a/smooth-app-bar-layout/src/main/java/me/henrytao/smoothappbarlayout/BaseBehavior.java
+++ b/smooth-app-bar-layout/src/main/java/me/henrytao/smoothappbarlayout/BaseBehavior.java
@@ -194,9 +194,6 @@ public abstract class BaseBehavior extends AppBarLayout.Behavior {
   }
 
   private View getScrollTarget(View target) {
-    if (target instanceof SwipeRefreshLayout && ((SwipeRefreshLayout) target).getChildCount() > 0) {
-      return ((SwipeRefreshLayout) target).getChildAt(0);
-    }
     return mScrollTargetCallback != null ? mScrollTargetCallback.callback(target) : target;
   }
 

--- a/smooth-app-bar-layout/src/main/java/me/henrytao/smoothappbarlayout/BaseBehavior.java
+++ b/smooth-app-bar-layout/src/main/java/me/henrytao/smoothappbarlayout/BaseBehavior.java
@@ -20,6 +20,7 @@ import android.content.Context;
 import android.support.design.widget.AppBarLayout;
 import android.support.design.widget.CoordinatorLayout;
 import android.support.v4.widget.NestedScrollView;
+import android.support.v4.widget.SwipeRefreshLayout;
 import android.support.v7.widget.RecyclerView;
 import android.util.AttributeSet;
 import android.view.View;
@@ -193,7 +194,23 @@ public abstract class BaseBehavior extends AppBarLayout.Behavior {
   }
 
   private View getScrollTarget(View target) {
-    return mScrollTargetCallback != null ? mScrollTargetCallback.callback(target) : target;
+    return mScrollTargetCallback != null ? mScrollTargetCallback.callback(target) : getSupportedScrollTarget(target);
+  }
+
+  private View getSupportedScrollTarget(View target) {
+    if (target instanceof SwipeRefreshLayout && ((SwipeRefreshLayout) target).getChildCount() > 0) {
+      SwipeRefreshLayout parent = (SwipeRefreshLayout) target;
+      View child;
+      int n = parent.getChildCount();
+      for (int i = 0; i < n; i++) {
+        child = parent.getChildAt(i);
+        if (child instanceof NestedScrollView || child instanceof RecyclerView) {
+          return child;
+        }
+      }
+      return ((SwipeRefreshLayout) target).getChildAt(0);
+    }
+    return target;
   }
 
   private void init(final CoordinatorLayout coordinatorLayout, final AppBarLayout child) {

--- a/smooth-app-bar-layout/src/main/java/me/henrytao/smoothappbarlayout/BaseBehavior.java
+++ b/smooth-app-bar-layout/src/main/java/me/henrytao/smoothappbarlayout/BaseBehavior.java
@@ -20,7 +20,6 @@ import android.content.Context;
 import android.support.design.widget.AppBarLayout;
 import android.support.design.widget.CoordinatorLayout;
 import android.support.v4.widget.NestedScrollView;
-import android.support.v4.widget.SwipeRefreshLayout;
 import android.support.v7.widget.RecyclerView;
 import android.util.AttributeSet;
 import android.view.View;

--- a/smooth-app-bar-layout/src/main/java/me/henrytao/smoothappbarlayout/SmoothAppBarLayout.java
+++ b/smooth-app-bar-layout/src/main/java/me/henrytao/smoothappbarlayout/SmoothAppBarLayout.java
@@ -151,7 +151,7 @@ public class SmoothAppBarLayout extends AppBarLayout {
 
   public void setScrollTargetCallback(ScrollTargetCallback scrollTargetCallback) {
     mScrollTargetCallback = scrollTargetCallback;
-    setBehaviorScrollTargetCallback();
+    //setBehaviorScrollTargetCallback();
   }
 
   public void syncOffset(int newOffset) {
@@ -184,6 +184,14 @@ public class SmoothAppBarLayout extends AppBarLayout {
     }
   }
 
+  //private void setBehaviorScrollTargetCallback() {
+  //  CoordinatorLayout.LayoutParams params = (CoordinatorLayout.LayoutParams) getLayoutParams();
+  //  SmoothAppBarLayout.Behavior behavior = (SmoothAppBarLayout.Behavior) params.getBehavior();
+  //  if (behavior != null) {
+  //    behavior.setScrollTargetCallback(mScrollTargetCallback);
+  //  }
+  //}
+
   private void setSyncOffsetListener(me.henrytao.smoothappbarlayout.base.OnOffsetChangedListener syncOffsetListener) {
     mSyncOffsetListener = syncOffsetListener;
     syncOffset(mRestoreCurrentOffset, true);
@@ -192,14 +200,6 @@ public class SmoothAppBarLayout extends AppBarLayout {
   private void syncOffset(int newOffset, boolean force) {
     if (mSyncOffsetListener != null) {
       mSyncOffsetListener.onOffsetChanged(this, newOffset, force);
-    }
-  }
-
-  private void setBehaviorScrollTargetCallback() {
-    CoordinatorLayout.LayoutParams params = (CoordinatorLayout.LayoutParams) getLayoutParams();
-    SmoothAppBarLayout.Behavior behavior = (SmoothAppBarLayout.Behavior) params.getBehavior();
-    if (behavior != null) {
-      behavior.setScrollTargetCallback(mScrollTargetCallback);
     }
   }
 
@@ -219,7 +219,7 @@ public class SmoothAppBarLayout extends AppBarLayout {
       }
       if (child instanceof SmoothAppBarLayout) {
         final SmoothAppBarLayout layout = (SmoothAppBarLayout) child;
-        layout.setBehaviorScrollTargetCallback();
+        setScrollTargetCallback(layout.mScrollTargetCallback);
         vViewPager = layout.vViewPager;
         if (vViewPager != null) {
           vViewPager.addOnPageChangeListener(new ViewPager.OnPageChangeListener() {

--- a/smooth-app-bar-layout/src/main/java/me/henrytao/smoothappbarlayout/SmoothAppBarLayout.java
+++ b/smooth-app-bar-layout/src/main/java/me/henrytao/smoothappbarlayout/SmoothAppBarLayout.java
@@ -151,6 +151,7 @@ public class SmoothAppBarLayout extends AppBarLayout {
 
   public void setScrollTargetCallback(ScrollTargetCallback scrollTargetCallback) {
     mScrollTargetCallback = scrollTargetCallback;
+    setBehaviorScrollTargetCallback();
   }
 
   public void syncOffset(int newOffset) {
@@ -194,6 +195,14 @@ public class SmoothAppBarLayout extends AppBarLayout {
     }
   }
 
+  private void setBehaviorScrollTargetCallback() {
+    CoordinatorLayout.LayoutParams params = (CoordinatorLayout.LayoutParams) getLayoutParams();
+    SmoothAppBarLayout.Behavior behavior = (SmoothAppBarLayout.Behavior) params.getBehavior();
+    if (behavior != null) {
+      behavior.setScrollTargetCallback(mScrollTargetCallback);
+    }
+  }
+
   public static class Behavior extends BaseBehavior {
 
     protected ScrollFlag mScrollFlag;
@@ -209,7 +218,9 @@ public class SmoothAppBarLayout extends AppBarLayout {
         mScrollFlag = new ScrollFlag(child);
       }
       if (child instanceof SmoothAppBarLayout) {
-        vViewPager = ((SmoothAppBarLayout) child).vViewPager;
+        final SmoothAppBarLayout layout = (SmoothAppBarLayout) child;
+        layout.setBehaviorScrollTargetCallback();
+        vViewPager = layout.vViewPager;
         if (vViewPager != null) {
           vViewPager.addOnPageChangeListener(new ViewPager.OnPageChangeListener() {
             @Override
@@ -222,12 +233,12 @@ public class SmoothAppBarLayout extends AppBarLayout {
 
             @Override
             public void onPageSelected(int position) {
-              propagateViewPagerOffset((SmoothAppBarLayout) child, true);
+              propagateViewPagerOffset(layout, true);
             }
           });
         }
 
-        ((SmoothAppBarLayout) child).setSyncOffsetListener(new me.henrytao.smoothappbarlayout.base.OnOffsetChangedListener() {
+        layout.setSyncOffsetListener(new me.henrytao.smoothappbarlayout.base.OnOffsetChangedListener() {
           @Override
           public void onOffsetChanged(SmoothAppBarLayout smoothAppBarLayout, int verticalOffset, boolean isOrientationChanged) {
             syncOffset(smoothAppBarLayout, -verticalOffset);


### PR DESCRIPTION
There was an issue with wrong scroll target on orientation change when RecyclerView is wrapped in SwipeRefreshLayout. The first child was CircleImageView, so the app bar layout offset wasn't properly synced. I've completely removed the logic related to detecting scroll target in SwipeRefreshLayout, I think this should be always done explicitly via SmoothAppBarLayout.setScrollTargetCallback.
I've also added an example that shows how to integrate with SwipeRefreshLayout.
