### PR TITLE
verticalOffset is not correct issue

### DIFF
--- a/smooth-app-bar-layout/src/main/java/me/henrytao/smoothappbarlayout/SmoothAppBarLayout.java
+++ b/smooth-app-bar-layout/src/main/java/me/henrytao/smoothappbarlayout/SmoothAppBarLayout.java
@@ -371,19 +371,7 @@ public class SmoothAppBarLayout extends AppBarLayout {
     }
 
     protected int getMinOffset(AppBarLayout layout) {
-      int minOffset = layout.getMeasuredHeight();
-      if (mScrollFlag != null) {
-        if (mScrollFlag.isFlagScrollEnabled()) {
-          minOffset = layout.getMeasuredHeight() - getMinHeight(layout, false);
-        }
-      }
-      if (ViewCompat.getFitsSystemWindows(layout)) {
-        if (mStatusBarSize == 0) {
-          mStatusBarSize = Utils.getStatusBarSize(layout.getContext());
-        }
-        minOffset -= mStatusBarSize;
-      }
-      return -Math.max(minOffset, 0);
+      return -layout.getTotalScrollRange();
     }
 
     private int getMinHeight(AppBarLayout layout, boolean forceQuickReturn) {


### PR DESCRIPTION
Sometimes verticalOffset is not correct with getTotalScrollRange
So I use extends Behavior and change this source
please change this
I can not English well.
So I can not explain in English
It's Translate

This is translator in google :
Often, the getTatalScrollRange value of AppBarLayout is not equal to the getMinOffset value, indicating that it will not move to the end.
As a result, the verticalOffset value of the OnOffsetChangedListener does not match the getTotalScrollRange value even though the scroll has been moved to the end.
So there are a lot of problems in creating my app.
After correcting as above, it is correct operation.
Please consider modifying